### PR TITLE
Baseline: capitalize `FAST-JAVA` to avoid duplicate Iceberg repo

### DIFF
--- a/src/BaselineOfCarrefour/BaselineOfCarrefour.class.st
+++ b/src/BaselineOfCarrefour/BaselineOfCarrefour.class.st
@@ -32,7 +32,7 @@ BaselineOfCarrefour >> defineDependencies: spec [
 	spec baseline: 'FASTJava' with: [
 		spec
 			loads: #( 'all' );
-			repository: 'github://moosetechnology/FAST-Java:v3.0.5/src' ].
+			repository: 'github://moosetechnology/FAST-JAVA:v3.0.5/src' ].
 	spec
 		baseline: 'Famix2Java'
 		with: [


### PR DESCRIPTION
This happens when you load Carrefour with other projects that have a common dependency on https://github.com/moosetechnology/FAST-JAVA.git.
The real culprit is pharo-project/pharo/issues/15033, this is a workaround.

<img width="466" alt="image" src="https://github.com/moosetechnology/Carrefour/assets/78592838/a9d7daf5-181f-408b-8587-d91f2a725c7d">