### PR TITLE
Replace `detect:ifOne:` with `detect:ifFound:`

### DIFF
--- a/src/Carrefour-FastAndBindingGenerator/CRFBinderVisitor.class.st
+++ b/src/Carrefour-FastAndBindingGenerator/CRFBinderVisitor.class.st
@@ -361,7 +361,7 @@ CRFBinderVisitor >> visitFASTJavaTypeParameter: aFASTJavaTypeParameter [
 
 	(self sourceFamixEntity allToScope: FamixTType)
 		detect: [ :type | type name = aFASTJavaTypeParameter name ]
-		ifOne: [ :type | type fastTypeDefinition: aFASTJavaTypeParameter ]
+		ifFound: [ :type | type fastTypeDefinition: aFASTJavaTypeParameter ]
 ]
 
 { #category : 'visitor' }


### PR DESCRIPTION
The `detect:ifOne:` method is from the CollectionExtensions project (transitive dependency through Famix), and has worse performance than the `detect:ifFound:` method originally found in the image.
I would also like to cut this dependency from Famix in the future.